### PR TITLE
Fix failing test snapshot

### DIFF
--- a/tests/testthat/_snaps/mutate.md
+++ b/tests/testthat/_snaps/mutate.md
@@ -144,7 +144,7 @@
     Output
       # A tibble: 0 x 2
       # Groups:   x [0]
-      # ... with 2 variables: x <dbl>, y <dbl>
+      # i 2 variables: x <dbl>, y <dbl>
 
 # mutate() give meaningful errors
 


### PR DESCRIPTION
Fix test snapshot, updating for changes in the display of a tibble that has zero rows.