### PR TITLE
Update mention of DuckDB in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -49,10 +49,10 @@ In addition to data frames/tibbles, dplyr makes working with other computational
 - [dbplyr](https://dbplyr.tidyverse.org/) for data stored in a relational 
   database. Translates your dplyr code to SQL.
 
-- [duckplyr](https://duckdblabs.github.io/duckplyr/) for using [duckdb](https://duckdb.org) on large, in-memory datasets with zero extra copies. Translates your dplyr code to high performance duckdb queries with an automatic R fallback when translation isn't possible.
-
-- [duckdb](https://duckdb.org/docs/api/r) for large datasets that are 
-  still small enough to fit on your computer.
+- [duckplyr](https://duckplyr.tidyverse.org/) for large, in-memory
+  datasets. Translates your dplyr code to high performance
+  [duckdb](https://duckdb.org) queries with zero extra copies and
+  an automatic R fallback when translation isn’t possible.
 
 - [sparklyr](https://spark.rstudio.com) for very large datasets stored in 
   [Apache Spark](https://spark.apache.org).

--- a/README.md
+++ b/README.md
@@ -51,13 +51,10 @@ alternative backends:
 - [dbplyr](https://dbplyr.tidyverse.org/) for data stored in a
   relational database. Translates your dplyr code to SQL.
 
-- [duckplyr](https://duckdblabs.github.io/duckplyr/) for using
-  [duckdb](https://duckdb.org) on large, in-memory datasets with zero
-  extra copies. Translates your dplyr code to high performance duckdb
-  queries with an automatic R fallback when translation isn’t possible.
-
-- [duckdb](https://duckdb.org/docs/api/r) for large datasets that are
-  still small enough to fit on your computer.
+- [duckplyr](https://duckplyr.tidyverse.org/) for large, in-memory
+  datasets. Translates your dplyr code to high performance
+  [duckdb](https://duckdb.org) queries with zero extra copies and
+  an automatic R fallback when translation isn’t possible.
 
 - [sparklyr](https://spark.rstudio.com) for very large datasets stored
   in [Apache Spark](https://spark.apache.org).


### PR DESCRIPTION
This commit makes the following changes to the README regarding the mentions of DuckDB:

- Removes the mention of the `duckdb` R package, which is not a `dplyr` backend, but rather a package purely for connecting to and querying a DuckDB database, like the dozens of similar packages that are specific to various database programs, and would likely be used with `dbplyr`.

- Corrects the broken link for the `duckplyr` package from https://duckdblabs.github.io/duckplyr/ to https://duckplyr.tidyverse.org/

- Changes the language of the mention of the `duckplyr` package to be consistent with the rest of the backend packages, following this order: name of the backend R package, use case, and underlying technology that the backend translates `dplyr` code to.